### PR TITLE
FIX extend function

### DIFF
--- a/html5csv.js
+++ b/html5csv.js
@@ -392,7 +392,7 @@ window.CSV = (function(){
 
     function extend(newCsvFuncs, newCsvShared){
 	if (typeof newCsvFuncs === "object"){ 
-	    $.extend(csvFuncs, newFuncs);
+	    $.extend(csvFuncs, newCsvFuncs);
 	} else { 
 	    throw "CSV: extend newCsvFuncs must be either an object with function values to extend csvFuncs or null for no extensions";
 	}


### PR DESCRIPTION
Following the wiki on [defining extension](/DrPaulBrewer/html5csv/wiki#defining-extensions) I created my first extension (add handsontable for display data) and I found this error: `Uncaught ReferenceError: newFuncs is not defined`

Digging in the code on the `function extend` (line 395) there is a typo: it uses `newFuncs` instead of `newCsvFuncs`.
