### PR TITLE
rewrite test - keeping original intent

### DIFF
--- a/qtestcsv.js
+++ b/qtestcsv.js
@@ -276,7 +276,7 @@ QUnit.test("local CSV to HTML table display and retrieve", postCreate(3, functio
 	    CSV.begin('#tab1').go(
 		function(ee,DD){
 		    assert.ok(!ee,"errors: "+ee);
-		    equal(JSON.stringify(D.rows), JSON.stringify(DD.rows), "data matches");
+		    assert.deepEqual(D.rows, DD.rows, "data matches");
 		}
 	    );
 	}


### PR DESCRIPTION
Change test from plain `equal` on JSON.strigified objects to assert.deepEqual on the objects themselves.